### PR TITLE
Modify download data fxn to also download meta/log files

### DIFF
--- a/esupy/processed_data_mgmt.py
+++ b/esupy/processed_data_mgmt.py
@@ -69,9 +69,9 @@ def download_from_remote(meta, paths):
                 folder = os.path.realpath(paths.local_path + '/' + meta.category)
                 file = folder + "/" + f
                 create_paths_if_missing(file)
+                log.info('%s saved to %s', f, folder)
                 with open(file, 'wb') as f:
                     f.write(r.content)
-                log.info('%s saved to %s', f, folder)
 
 
 def remove_extra_files(file_meta, paths):

--- a/esupy/processed_data_mgmt.py
+++ b/esupy/processed_data_mgmt.py
@@ -49,22 +49,23 @@ def load_preprocessed_output(file_meta, paths):
 
 def download_from_remote(meta, paths, **kwargs):
     """
-    Downloads a preprocessed file from remote and stores locally based on the
-    most recent instance of that file
+    Downloads one or more files from remote and stores locally based on the
+    most recent instance of that file. All files that share name_data, version, and
+    hash will be downloaded together.
     :param meta: populated instance of class FileMeta
     :param paths: instance of class Paths
     :param kwargs: option to include 'subdirectory_dict', a dictionary that
-         directs local data storage location
+         directs local data storage location based on extension
     """
     category = meta.tool + '/'
     if meta.category != '':
         category = category + meta.category + '/'
     base_url = paths.remote_path + category
-    file_name = get_most_recent_from_index(meta.name_data, category, paths)
-    if file_name == []:
+    files = get_most_recent_from_index(meta.name_data, category, paths)
+    if files == []:
         log.info('%s not found in %s', meta.name_data, base_url)
     else:
-        for f in file_name:
+        for f in files:
             url = base_url + f
             r = make_http_request(url)
             if r is not None:
@@ -153,7 +154,7 @@ def find_file(meta,paths):
 def get_most_recent_from_index(file_name, category, paths):
     """
     Sorts the data commons index by most recent date and returns
-    the matching file name
+    the matching files of that name that share the same version and hash
     :param file_name:
     :param category:
     :param paths:

--- a/esupy/processed_data_mgmt.py
+++ b/esupy/processed_data_mgmt.py
@@ -47,30 +47,30 @@ def load_preprocessed_output(file_meta, paths):
         return None
 
 
-def download_from_remote(meta, paths, **kwargs):
+def download_from_remote(file_meta, paths, **kwargs):
     """
     Downloads one or more files from remote and stores locally based on the
     most recent instance of that file. All files that share name_data, version, and
     hash will be downloaded together.
-    :param meta: populated instance of class FileMeta
+    :param file_meta: populated instance of class FileMeta
     :param paths: instance of class Paths
     :param kwargs: option to include 'subdirectory_dict', a dictionary that
          directs local data storage location based on extension
     """
-    category = meta.tool + '/'
-    if meta.category != '':
-        category = category + meta.category + '/'
+    category = file_meta.tool + '/'
+    if file_meta.category != '':
+        category = category + file_meta.category + '/'
     base_url = paths.remote_path + category
-    files = get_most_recent_from_index(meta.name_data, category, paths)
+    files = get_most_recent_from_index(file_meta.name_data, category, paths)
     if files == []:
-        log.info('%s not found in %s', meta.name_data, base_url)
+        log.info('%s not found in %s', file_meta.name_data, base_url)
     else:
         for f in files:
             url = base_url + f
             r = make_http_request(url)
             if r is not None:
                 # set subdirectory
-                subdirectory = meta.category
+                subdirectory = file_meta.category
                 # if there is a dictionary with specific subdirectories
                 # based on end of filename, modify the subdirectory
                 if kwargs != {}:

--- a/esupy/processed_data_mgmt.py
+++ b/esupy/processed_data_mgmt.py
@@ -153,8 +153,8 @@ def find_file(meta,paths):
 
 def get_most_recent_from_index(file_meta, paths):
     """
-    Sorts the data commons index by most recent date and returns
-    the matching files of that name that share the same version and hash
+    Sorts the data commons index by most recent date for the required extension 
+    and returns the matching files of that name that share the same version and hash
     :param file_meta:
     :param paths:
     :return: list, most recently created datafiles, metadata, log files
@@ -165,13 +165,14 @@ def get_most_recent_from_index(file_meta, paths):
         return None
     file_df = parse_data_commons_index(file_df)
     df = file_df[file_df['name']==file_meta.name_data]
-    if len(df) == 0:
+    df_ext = df[df['ext']==file_meta.extension]
+    if len(df_ext) == 0:
         return None
     else:
-        df = df.sort_values(by='date', ascending=False).reset_index(drop=True)
+        df_ext = df_ext.sort_values(by='date', ascending=False).reset_index(drop=True)
         # select first file name in list, extract the file version and git hash,
         # return list of files that include version/hash (to include metadata and log files)
-        recent_file = df['file_name'][0]
+        recent_file = df_ext['file_name'][0]
         vh = "_".join(strip_file_extension(recent_file).replace(
             f'{file_meta.name_data}_', '').split("_", 2)[:2])
         if vh != '':

--- a/esupy/processed_data_mgmt.py
+++ b/esupy/processed_data_mgmt.py
@@ -61,7 +61,7 @@ def download_from_remote(file_meta, paths, **kwargs):
     if file_meta.category != '':
         category = category + file_meta.category + '/'
     base_url = paths.remote_path + category
-    files = get_most_recent_from_index(file_meta.name_data, category, paths)
+    files = get_most_recent_from_index(file_meta, paths)
     if files == []:
         log.info('%s not found in %s', file_meta.name_data, base_url)
     else:
@@ -151,21 +151,20 @@ def find_file(meta,paths):
     return f
 
 
-def get_most_recent_from_index(file_name, category, paths):
+def get_most_recent_from_index(file_meta, paths):
     """
     Sorts the data commons index by most recent date and returns
     the matching files of that name that share the same version and hash
-    :param file_name:
-    :param category:
+    :param file_meta:
     :param paths:
     :return: list, most recently created datafiles, metadata, log files
     """
 
-    file_df = get_data_commons_index(paths, category)
+    file_df = get_data_commons_index(paths, file_meta.category)
     if file_df is None:
         return None
     file_df = parse_data_commons_index(file_df)
-    df = file_df[file_df['name']==file_name]
+    df = file_df[file_df['name']==file_meta.name_data]
     if len(df) == 0:
         return None
     else:
@@ -173,7 +172,8 @@ def get_most_recent_from_index(file_name, category, paths):
         # select first file name in list, extract the file version and git hash,
         # return list of files that include version/hash (to include metadata and log files)
         recent_file = df['file_name'][0]
-        vh = "_".join(strip_file_extension(recent_file).replace(f'{file_name}_', '').split("_", 2)[:2])
+        vh = "_".join(strip_file_extension(recent_file).replace(
+            f'{file_meta.name_data}_', '').split("_", 2)[:2])
         if vh != '':
             df_sub = [string for string in df['file_name'] if vh in string]
         else:

--- a/esupy/processed_data_mgmt.py
+++ b/esupy/processed_data_mgmt.py
@@ -162,7 +162,10 @@ def get_most_recent_from_index(file_name, category, paths):
         # return list of files that include version/hash (to include metadata and log files)
         recent_file = df['file_name'][0]
         vh = "_".join(strip_file_extension(recent_file).replace(f'{file_name}_', '').split("_", 2)[:2])
-        df_sub = [string for string in df['file_name'] if vh in string]
+        if vh != '':
+            df_sub = [string for string in df['file_name'] if vh in string]
+        else:
+            df_sub = [recent_file]
         return df_sub
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='esupy',
-    version='0.1.4',
+    version='0.1.7',
     packages=['esupy'],
     install_requires=['requests >=2.22.0',
                       'appdirs>=1.4.3',


### PR DESCRIPTION
- Update get_most_recent_from_index() to return a list of file names rather than singular nume
---- list of file names have the same version and git hash as the most recent file in the list
---- any file with the identified version/hash is downloaded
---- allows for multiple log files/meta/any possible future files uploaded

- Potential issue with data that do not have version/hash