### PR TITLE
Fix make_http_request

### DIFF
--- a/esupy/processed_data_mgmt.py
+++ b/esupy/processed_data_mgmt.py
@@ -12,7 +12,7 @@ import re
 import json
 import appdirs
 import xml.etree.ElementTree as ET
-from esupy.remote import make_http_request
+from esupy.remote import make_url_request
 from esupy.util import strip_file_extension
 
 
@@ -69,7 +69,7 @@ def download_from_remote(file_meta, paths, **kwargs):
     else:
         for f in files:
             url = base_url + f
-            r = make_http_request(url)
+            r = make_url_request(url)
             if r is not None:
                 # set subdirectory
                 subdirectory = file_meta.category
@@ -311,7 +311,7 @@ def get_data_commons_index(file_meta, paths):
     if file_meta.category != '':
         subdirectory = subdirectory + file_meta.category + '/'
     url = paths.remote_path + index_url + subdirectory
-    listing = make_http_request(url)
+    listing = make_url_request(url)
     # Code to convert XML to pd df courtesy of
     # https://stackabuse.com/reading-and-writing-xml-files-in-python-with-panda
     contents = ET.XML(listing.text)

--- a/esupy/processed_data_mgmt.py
+++ b/esupy/processed_data_mgmt.py
@@ -2,7 +2,8 @@
 # !/usr/bin/env python3
 # coding=utf-8
 """
-Functions to manage querying, retrieving and storing of preprocessed data in local directories
+Functions to manage querying, retrieving and storing of preprocessed data in
+local directories
 """
 import logging as log
 import os
@@ -13,6 +14,7 @@ import appdirs
 import xml.etree.ElementTree as ET
 from esupy.remote import make_http_request
 from esupy.util import strip_file_extension
+
 
 class Paths:
     def __init__(self):
@@ -37,9 +39,10 @@ def load_preprocessed_output(file_meta, paths):
     Loads a preprocessed file
     :param file_meta: populated instance of class FileMeta
     :param paths: instance of class Paths
-    :return: a pandas dataframe of the datafile if exists or None if it doesn't exist
+    :return: a pandas dataframe of the datafile if exists or None if it
+        doesn't exist
     """
-    f = find_file(file_meta,paths)
+    f = find_file(file_meta, paths)
     if os.path.exists(f):
         df = read_into_df(f)
         return df
@@ -50,8 +53,8 @@ def load_preprocessed_output(file_meta, paths):
 def download_from_remote(file_meta, paths, **kwargs):
     """
     Downloads one or more files from remote and stores locally based on the
-    most recent instance of that file. All files that share name_data, version, and
-    hash will be downloaded together.
+    most recent instance of that file. All files that share name_data, version,
+    and hash will be downloaded together.
     :param file_meta: populated instance of class FileMeta
     :param paths: instance of class Paths
     :param kwargs: option to include 'subdirectory_dict', a dictionary that
@@ -77,7 +80,8 @@ def download_from_remote(file_meta, paths, **kwargs):
                         for k, v in kwargs['subdirectory_dict'].items():
                             if f.endswith(k):
                                 subdirectory = v
-                folder = os.path.realpath(paths.local_path + '/' + subdirectory)
+                folder = os.path.realpath(paths.local_path
+                                          + '/' + subdirectory)
                 file = folder + "/" + f
                 create_paths_if_missing(file)
                 log.info('%s saved to %s', f, folder)
@@ -102,21 +106,21 @@ def remove_extra_files(file_meta, paths):
         # get file creation time
         st = f.stat().st_ctime
         if name.startswith(file_name):
-            fs[name]=st
+            fs[name] = st
     keep = max(fs, key=fs.get)
     log.debug("found %i files", len(fs))
     count = 0
     for f in fs.keys():
         if f is not keep:
             os.remove(path + "/" + f)
-            count +=1
+            count += 1
     log.debug("removed %i files", count)
 
 
-def find_file(meta,paths):
+def find_file(meta, paths):
     """
-    Searches for file within path.local_path based on file metadata, if metadata matches,
-     returns most recently created file name
+    Searches for file within path.local_path based on file metadata, if
+    metadata matches, returns most recently created file name
     :param meta: populated instance of class FileMeta
     :param paths: populated instance of class Paths
     :return: str with the file path if found, otherwise an empty string
@@ -130,20 +134,22 @@ def find_file(meta,paths):
             name = f.name
             # get file creation time
             st = f.stat().st_ctime
-            fs[name]=st
+            fs[name] = st
             matches = []
             for k in fs.keys():
                 if re.search(search_words, k):
                     if re.search(meta.ext, k, re.IGNORECASE):
-                        matches.append(k)                    
+                        matches.append(k)
         if len(matches) == 0:
             f = ""
         else:
             # Filter the dict by matches
-            r = {k:v for k,v in fs.items() if k in matches}
+            r = {k: v for k, v in fs.items() if k in matches}
             # Sort the dict by matches, return a list
-            #r = {k:v for k,v in sorted(r.items(), key=lambda item: item[1], reverse=True)}
-            rl = [k for k,v in sorted(r.items(), key=lambda item: item[1], reverse=True)]
+            # r = {k:v for k,v in sorted(r.items(),
+            #      key=lambda item: item[1], reverse=True)}
+            rl = [k for k, v
+                  in sorted(r.items(), key=lambda item: item[1], reverse=True)]
             f = os.path.realpath(path + "/" + rl[0])
     else:
         f = ""
@@ -152,8 +158,9 @@ def find_file(meta,paths):
 
 def get_most_recent_from_index(file_meta, paths):
     """
-    Sorts the data commons index by most recent date for the required extension 
-    and returns the matching files of that name that share the same version and hash
+    Sorts the data commons index by most recent date for the required extension
+    and returns the matching files of that name that share the same version
+    and hash
     :param file_meta:
     :param paths:
     :return: list, most recently created datafiles, metadata, log files
@@ -164,13 +171,15 @@ def get_most_recent_from_index(file_meta, paths):
         return None
     file_df = parse_data_commons_index(file_df)
     df = file_df[file_df['name'].str.startswith(file_meta.name_data)]
-    df_ext = df[df['ext']==file_meta.ext]
+    df_ext = df[df['ext'] == file_meta.ext]
     if len(df_ext) == 0:
         return None
     else:
-        df_ext = df_ext.sort_values(by='date', ascending=False).reset_index(drop=True)
-        # select first file name in list, extract the file version and git hash,
-        # return list of files that include version/hash (to include metadata and log files)
+        df_ext = (df_ext.sort_values(by='date', ascending=False)
+                  .reset_index(drop=True))
+        # select first file name in list, extract the file version and git
+        # hash, return list of files that include version/hash (to include
+        # metadata and log files)
         recent_file = df_ext['file_name'][0]
         vh = "_".join(strip_file_extension(recent_file).replace(
             f'{file_meta.name_data}_', '').split("_", 2)[:2])
@@ -181,9 +190,10 @@ def get_most_recent_from_index(file_meta, paths):
         return df_sub
 
 
-def write_df_to_file(df,paths,meta):
+def write_df_to_file(df, paths, meta):
     """
-    Writes a data frame to the designated local folder and file name created using paths and meta
+    Writes a data frame to the designated local folder and file name created
+    using paths and meta
     :param df: a pandas dataframe
     :param paths: populated instance of class Paths
     :param meta: populated instance of class FileMeta
@@ -195,7 +205,7 @@ def write_df_to_file(df,paths,meta):
         file = file + "_" + meta.git_hash
     try:
         create_paths_if_missing(file)
-        if meta.ext=="parquet":
+        if meta.ext == "parquet":
             file = file + ".parquet"
             file = os.path.realpath(file)
             df.to_parquet(file, engine="pyarrow")
@@ -204,30 +214,34 @@ def write_df_to_file(df,paths,meta):
             file = os.path.realpath(file)
             df.to_csv(file, index=False)
         else:
-            log.error('Failed to save ' + file + '. ' + "Meta data lacks 'ext' property")
+            log.error('Failed to save ' + file + '. '
+                      + "Meta data lacks 'ext' property")
     except:
-        log.error('Failed to save '+ file + '.')
+        log.error('Failed to save ' + file + '.')
+
 
 def read_into_df(file):
     """
     Based on a file extension use the appropriate function to read in file
     :param file: str with a file path
-    :return: a pandas dataframe with the file data if extension is handled, else an error
+    :return: a pandas dataframe with the file data if extension is handled,
+        else an error
     """
     df = pd.DataFrame()
-    name,ext = os.path.splitext(file)
+    name, ext = os.path.splitext(file)
     ext = ext.lower()
-    if ext==".parquet":
+    if ext == ".parquet":
         df = pd.read_parquet(file)
-    elif ext==".csv":
+    elif ext == ".csv":
         df = pd.read_csv(file)
     else:
         log.error("No reader specified for extension"+ext)
     return df
 
-#def define_metafile(datafile,paths):
+# def define_metafile(datafile,paths):
 #    data = strip_file_extension(datafile)
-#    metafile = os.path.realpath(paths.local_path + "/" + data + '_metadata.json')
+#    metafile = os.path.realpath(paths.local_path + "/" + data
+#                                + '_metadata.json')
 #    return metafile
 
 
@@ -243,13 +257,13 @@ def write_metadata_to_file(paths, meta):
         file = file + "_" + meta.git_hash
     file = file + '_metadata.json'
     with open(file, 'w') as file:
-        file.write(json.dumps(meta.__dict__, indent = 4))
+        file.write(json.dumps(meta.__dict__, indent=4))
 
 
-def read_source_metadata(paths, meta, force_JSON = False):
+def read_source_metadata(paths, meta, force_JSON=False):
     """return the locally saved metadata dictionary from JSON,
     meta should reflect the outputfile for which the metadata is associated
-    
+
     :param meta: object of class FileMeta used to load the outputfile
     :param paths: object of class Paths
     :param force_JSON: bool, searches based on named JSON instead of outputfile
@@ -271,7 +285,7 @@ def read_source_metadata(paths, meta, force_JSON = False):
     except FileNotFoundError:
         log.warning("metadata not found for %s", meta.name_data)
         return None
-    
+
 
 def create_paths_if_missing(file):
     """
@@ -307,7 +321,7 @@ def get_data_commons_index(file_meta, paths):
         data.append([subchild.text for subchild in child])
         cols.append(child.tag)
     df = pd.DataFrame(data)
-    df.dropna(inplace = True)
+    df.dropna(inplace=True)
     try:
         # only get first two columns and rename them name and last modified
         df = df[[0, 1]]
@@ -317,11 +331,11 @@ def get_data_commons_index(file_meta, paths):
     df.columns = ['file_name', 'last_modified']
     # Reformat the date to a pd datetime
     df['date'] = pd.to_datetime(df['last_modified'],
-                                format = '%Y-%m-%dT%H:%M:%S')
+                                format='%Y-%m-%dT%H:%M:%S')
     # Remove the category name and trailing slash from the file name
-    df['file_name'] = df['file_name'].str.replace(subdirectory,"")
+    df['file_name'] = df['file_name'].str.replace(subdirectory, "")
     # Reset the index and return
-    df = df[['date','file_name']].reset_index(drop=True)
+    df = df[['date', 'file_name']].reset_index(drop=True)
     return df
 
 
@@ -331,16 +345,16 @@ def parse_data_commons_index(df):
     df['file'] = df['file_name'].str.rsplit(".", n=1, expand=True)[0]
     df['git_hash'] = df['file'].str.rsplit("_", n=1, expand=True)[1]
     df['git_hash'].fillna('', inplace=True)
-    df.loc[df['git_hash'].map(len)!=7, 'git_hash'] = ''
+    df.loc[df['git_hash'].map(len) != 7, 'git_hash'] = ''
     try:
-        df['version'] = df['file'].str.split("_v", n=1, expand=True)[1].str.split(
-            "_", expand=True)[0]
+        df['version'] = (df['file']
+                         .str.split("_v", n=1, expand=True)[1]
+                         .str.split("_", expand=True)[0])
         df['name'] = df['file'].str.split("_v", n=1, expand=True)[0]
     except KeyError:
         df['version'] = ''
         df['name'] = df['file']
-    df = df[['name','version','git_hash',
-             'ext','date', 'file_name']].reset_index(drop=True)
+    df = df[['name', 'version', 'git_hash',
+             'ext', 'date', 'file_name']].reset_index(drop=True)
     df.fillna('', inplace=True)
     return df
-

--- a/esupy/remote.py
+++ b/esupy/remote.py
@@ -10,7 +10,7 @@ import requests_ftp
 from urllib.parse import urlsplit
 
 
-def make_http_request(url):
+def make_url_requesturl):
     """
     Makes http request using requests library
     :param url: URL to query
@@ -27,3 +27,12 @@ def make_http_request(url):
         except requests.exceptions.HTTPError:
             log.error('Error in URL request!')
     return response
+
+
+# Alias for backward compatibility
+def make_http_request(url):
+    log.warning('esupy.remote.make_http_request() has been renamed to '
+                'esupy.remote.make_url_request(). '
+                'esupy.remote.make_http_request() will be removed in the '
+                'future. Please modify your code accordingly.')
+    return make_url_request(url)

--- a/esupy/remote.py
+++ b/esupy/remote.py
@@ -10,7 +10,7 @@ import requests_ftp
 from urllib.parse import urlsplit
 
 
-def make_url_requesturl):
+def make_url_request(url):
     """
     Makes http request using requests library
     :param url: URL to query

--- a/esupy/remote.py
+++ b/esupy/remote.py
@@ -10,7 +10,7 @@ import requests_ftp
 from urllib.parse import urlsplit
 
 
-def make_url_request(url):
+def make_url_request(url, set_cookies=False):
     """
     Makes http request using requests library
     :param url: URL to query
@@ -20,6 +20,10 @@ def make_url_request(url):
                else requests.Session)
     with session() as s:
         try:
+            # The session object s preserves cookies, so the second s.get()
+            # will have the cookies that came from the first s.get()
+            if set_cookies:
+                s.get(url)
             response = s.get(url)
             response.raise_for_status()
         except requests.exceptions.ConnectionError:


### PR DESCRIPTION
Improved control flow and robustness of `make_http_request`, and renamed it as `make_url_request` to reflect the fact that it can make FTP requests as well. I also provided `make_http_request` as an alias for `make_url_request`, with a logged deprecation warning, since `stewi` imports and uses `make_http_request` from this package(I've also submitted a PR on `stewi` to change the name).