### PR TITLE
Add confirm to make url request()

### DIFF
--- a/esupy/remote.py
+++ b/esupy/remote.py
@@ -26,9 +26,9 @@ def make_url_request(url, *, set_cookies=False, confirm_gdrive=False):
             if set_cookies:
                 response = s.get(url)
             if confirm_gdrive:
-                response = s.get(url, params={'confirm': response.cookies
-                                              .items()
-                                              .get('download_warning')})
+                confirmation_token = [v for k, v in response.cookies.items()
+                                      if k.startswith('download_warning')][0]
+                response = s.get(url, params={'confirm': confirmation_token})
             response.raise_for_status()
         except requests.exceptions.ConnectionError:
             log.error("URL Connection Error for %s", url)

--- a/esupy/remote.py
+++ b/esupy/remote.py
@@ -10,7 +10,7 @@ import requests_ftp
 from urllib.parse import urlsplit
 
 
-def make_url_request(url, set_cookies=False):
+def make_url_request(url, *, set_cookies=False, confirm_gdrive=False, **_):
     """
     Makes http request using requests library
     :param url: URL to query
@@ -22,9 +22,13 @@ def make_url_request(url, set_cookies=False):
         try:
             # The session object s preserves cookies, so the second s.get()
             # will have the cookies that came from the first s.get()
-            if set_cookies:
-                s.get(url)
             response = s.get(url)
+            if set_cookies:
+                response = s.get(url)
+            if confirm_gdrive:
+                response = s.get(url, params={'confirm': response.cookies
+                                              .items()
+                                              .get('download_warning')})
             response.raise_for_status()
         except requests.exceptions.ConnectionError:
             log.error("URL Connection Error for %s", url)

--- a/esupy/remote.py
+++ b/esupy/remote.py
@@ -10,7 +10,7 @@ import requests_ftp
 from urllib.parse import urlsplit
 
 
-def make_url_request(url, *, set_cookies=False, confirm_gdrive=False, **_):
+def make_url_request(url, *, set_cookies=False, confirm_gdrive=False):
     """
     Makes http request using requests library
     :param url: URL to query


### PR DESCRIPTION
When downloading a large file from Google drive, a confirmation token must be read form the first response's cookies and then resubmitted as a parameter. This enables that functionality. It also makes the old `set_cookies` parameter and the new `confirm_gdrive` parameter keyword only so that there can't be any confusion in the future about what is being set to `True`/`False`. This does not require any changes to other files in the `esupy`/`flowsa`/`stewi` ecosystem, since the only time the `set_cookies` argument was supplied, it was supplied by keyword.