### PR TITLE
define the directory path from which to base generating a git hash

### DIFF
--- a/esupy/util.py
+++ b/esupy/util.py
@@ -4,10 +4,11 @@
 """
 Simple utility functions for reuse in tools
 """
+import inspect
 import os
 import subprocess
 
-supported_ext = ["parquet","csv"]
+supported_ext = ["parquet", "csv"]
 
 
 def strip_file_extension(filename):
@@ -16,18 +17,19 @@ def strip_file_extension(filename):
     :param filename: a string representing a file name; can contain path
     :return: string, filename without extension
     """
-    return(filename.rsplit(".", 1)[0])
+    return filename.rsplit(".", 1)[0]
 
 
-def is_git_directory(path = '.'):
+def is_git_directory(path='.'):
     """
     Returns True if path contains git directory
     """
     return subprocess.call(['git', '-C', path, 'status'],
                            stderr=subprocess.STDOUT,
-                           stdout = open(os.devnull, 'w')) == 0
+                           stdout=open(os.devnull, 'w')) == 0
 
-def get_git_hash(length = 'short'):
+
+def get_git_hash(length='short'):
     """
     Returns git_hash of current directory or None if no git found
     :param length: str, 'short' for 7-digit, 'long' for full git hash
@@ -36,9 +38,16 @@ def get_git_hash(length = 'short'):
     git_hash = None
     if is_git_directory():
         try:
+            # Define the directory path where this function is called.
+            # Necessary when running scripts located outside of a repository,
+            # but want the git hash of the repository
+            dirpath = os.path.dirname(os.path.abspath((inspect.stack()[1])[1]))
+
             git_hash = subprocess.check_output(
-                ['git', 'rev-parse', 'HEAD']).strip().decode('ascii')
+                ['git', 'rev-parse', 'HEAD'], cwd=dirpath).strip().decode(
+                'ascii')
             if length == 'short':
                 git_hash = git_hash[0:7]
-        except: pass
+        except:
+            pass
     return git_hash


### PR DESCRIPTION
Addresses the [issue in FLOWSA](https://github.com/USEPA/flowsa/issues/172) where running an FBS method file outside the repo results in the parquet name using the git hash from the wrong repo