### PR TITLE
Gdrive confirm now requires only a fixed parameter

### DIFF
--- a/esupy/remote.py
+++ b/esupy/remote.py
@@ -26,9 +26,7 @@ def make_url_request(url, *, set_cookies=False, confirm_gdrive=False):
             if set_cookies:
                 response = s.get(url)
             if confirm_gdrive:
-                confirmation_token = [v for k, v in response.cookies.items()
-                                      if k.startswith('download_warning')][0]
-                response = s.get(url, params={'confirm': confirmation_token})
+                response = s.get(url, params={'confirm': 't'})
             response.raise_for_status()
         except requests.exceptions.ConnectionError:
             log.error("URL Connection Error for %s", url)


### PR DESCRIPTION
It appears that Google drive no longer requires getting a confirmation token from the cookies in order to download a large file, just a fixed parameter submitted in the url. This changes the behavior of `remote.make_url_request()` to accommodate this change.