### PR TITLE
tweaked error handling in make_url_request

### DIFF
--- a/esupy/remote.py
+++ b/esupy/remote.py
@@ -35,17 +35,14 @@ def make_url_request(url, *, set_cookies=False, confirm_gdrive=False,
                     response = s.get(url, params={'confirm': 't'})
                 response.raise_for_status()
                 break
-            except requests.exceptions.ConnectionError as err:
-                log.debug(err)
-                time.sleep(5)
-                continue
-            except requests.exceptions.HTTPError as err:
-                log.debug(err)
-                time.sleep(5)
-                continue
-        else:
-            log.exception(err)
-            raise
+            except requests.exceptions.RequestException as err:
+                if attempt < max_attempts - 1:
+                    log.debug(err)
+                    time.sleep(5)
+                    continue
+                else:
+                    log.exception(err)
+                    raise
     return response
 
 


### PR DESCRIPTION
What I was thinking was an `if: ... else: ...` inside the `except:` block, as seen here. You make a good point about the `requests.exceptions.RequestException` error being more generic than `HTTPError` and `ConnectionError`, but it turns out that `HTTPError` and `ConnectionError` both inherit from `RequestException`, so we can use a single `except:` clause to handle all of them.

Also, when we use `raise` in an `except:` block _without_ specifying what exception to raise, it will just re-raise whatever exception the `except:` block caught, which I think is desirable behavior so we don't lose information by raising a generic exceptio instead of the specific exception that actually happened.