### PR TITLE
v0.3.2-release

### DIFF
--- a/esupy/dqi.py
+++ b/esupy/dqi.py
@@ -119,10 +119,10 @@ def get_weighted_average(df, data_col, weight_col, agg_cols):
     df_agg[data_col] = get_weighted_average(df, data_col,
                                             weight_col, agg_cols)
     """
-    df.loc[:, '_data_times_weight'] = df[data_col] * df[weight_col]
-    df.loc[:, '_weight_where_notnull'] = df[weight_col] * pd.notnull(df[data_col])
-    calc_cols = ['_weight_where_notnull', '_data_times_weight']
-    df[calc_cols] = df[calc_cols].applymap(float)
+    df = (df.assign(_data_times_weight = lambda x: x[data_col] * x[weight_col])
+            .assign(_weight_where_notnull = lambda x:
+                    x[weight_col] * pd.notnull(x[data_col]))
+            )
     g = df.groupby(agg_cols)
     wt_avg = np.divide(g['_data_times_weight'].sum(), g['_weight_where_notnull'].sum(),
                        out=np.zeros_like(g['_data_times_weight'].sum()),

--- a/esupy/processed_data_mgmt.py
+++ b/esupy/processed_data_mgmt.py
@@ -70,10 +70,6 @@ def download_from_remote(file_meta, paths, **kwargs):
     base_url = paths.remote_path + file_meta.tool + '/'
     if file_meta.category != '':
         base_url = base_url + file_meta.category + '/'
-    ## TODO: re-implement URL handling via f-strings and/or urllib
-    # base_url = f'{paths.remote_path}/{file_meta.tool}'
-    # if not file_meta.category == '':
-    #     base_url = f'{base_url}/{file_meta.category}'
     files = get_most_recent_from_index(file_meta, paths)
     if files is None:
         log.info(f'{file_meta.name_data} not found in {base_url}')
@@ -173,7 +169,9 @@ def get_most_recent_from_index(file_meta, paths):
     if file_df is None:
         return None
     file_df = parse_data_commons_index(file_df)
-    df = file_df[file_df['name'].str.startswith(file_meta.name_data)]
+    # subset using "file_name" instead of "name" to work when a user
+    # includes a GitHub version and hash
+    df = file_df[file_df['file_name'].str.startswith(file_meta.name_data)]
     df_ext = df[df['ext'] == file_meta.ext]
     if len(df_ext) == 0:
         return None


### PR DESCRIPTION
add ability to include a version and/or hash when downloading data commons files

In flowsa (and I assume other packages), we were not able to specify a file version and/or hash when downloading files from data commons. For example:
`flowsa.collapse_FlowBySector("GHG_national_2018_m2_v2.0.0_a8c5929",download_FBS_if_missing=True)`
was failing. We could only run:
`flowsa.collapse_FlowBySector("GHG_national_2018_m2",download_FBS_if_missing=True)`

This PR modifies how files are found on data commons so users can specify versions/hashes